### PR TITLE
Support case sensitive tokens

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -26,6 +26,7 @@ var passport = require('passport-strategy'),
  *   - `tokenParams`  params name where the token is found, defaults to 'token'
  *   - `tokenHeader`  header name where the token is found, defaults to 'token'
  *   - `passReqToCallback`  when `true`, `req` is the first argument to the verify callback (default: `false`)
+ *   - `caseSensitive`  when `true` the token validation is case Sensitive (default: `false`)
  *
  * Examples:
  *
@@ -51,13 +52,13 @@ function Strategy(options, verify) {
     throw new TypeError('Token authentication strategy requires a verify function');
   }
 
-  this._tokenField = options.tokenField ? options.tokenField.toLowerCase() : 'token';
+  this._tokenField = sanitizeToken(options, 'tokenField', 'token');
 
-  this._tokenQuery = options.tokenQuery ? options.tokenQuery.toLowerCase() : this._tokenField;
+  this._tokenQuery = sanitizeToken(options, 'tokenQuery', this._tokenField);
 
-  this._tokenParams = options.tokenParams ? options.tokenParams.toLowerCase() : this._tokenField;
+  this._tokenParams = sanitizeToken(options, 'tokenParams', this._tokenField);
 
-  this._tokenHeader = options.tokenHeader ? options.tokenHeader.toLowerCase() : this._tokenField;
+  this._tokenHeader = sanitizeToken(options, 'tokenHeader', this._tokenField);
 
   this._failOnMissing = options.failedOnMissing !== undefined ? !!options.failedOnMissing : true;
 
@@ -65,6 +66,13 @@ function Strategy(options, verify) {
   this.name = 'token';
   this._verify = verify;
   this._passReqToCallback = options.passReqToCallback;
+}
+
+function sanitizeToken(options, optionsField, defaultToken) {
+  var token = options[optionsField];
+  if (!token) return defaultToken;
+
+  return options.caseSensitive ? token : token.toLowerCase();
 }
 
 /**

--- a/tests/strategy.fields.test.js
+++ b/tests/strategy.fields.test.js
@@ -42,39 +42,69 @@ describe('Strategy', function() {
     });
   });
 
-  describe('handling a request with valid credentials in body using case sensitive custom field name', function() {
-    var strategy = new Strategy({tokenField: 'uniqToken', caseSensitive: true}, function(token, done) {
-      if (token === 'sdvoihweui3498d9vhwoufhi8h') {
-        return done(null, {id: '1234'}, {scope: 'read'});
-      }
-      return done(null, false);
+  describe('using case sensitive custom field name', function () {    
+    describe('handling a request with valid credentials in body', function() {
+       var strategy = new Strategy({tokenField: 'uniqToken', caseSensitive: true}, function(token, done) {
+        if (token === 'sdvoihweui3498d9vhwoufhi8h') {
+          return done(null, {id: '1234'}, {scope: 'read'});
+        }
+        return done(null, false);
+      });
+      
+      var user,
+        info;
+
+      before(function(done) {
+        chai.passport(strategy)
+          .success(function(u, i) {
+            user = u;
+            info = i;
+            done();
+          })
+          .req(function(req) {
+            req.body = {};
+            req.body.uniqToken = 'sdvoihweui3498d9vhwoufhi8h';
+          })
+          .authenticate();
+      });
+
+      it('should supply user', function() {
+        expect(user).to.be.an.object;
+        expect(user.id).to.equal('1234');
+      });
+
+      it('should supply info', function() {
+        expect(info).to.be.an.object;
+        expect(info.scope).to.equal('read');
+      });
     });
 
-    var user,
-      info;
+    describe('handling a request with invalid credentials', function() {
+      var strategy = new Strategy({tokenField: 'uniqToken', caseSensitive: true}, function(token, done) {
+        throw new Error('should not be called');
+      });
 
-    before(function(done) {
-      chai.passport(strategy)
-        .success(function(u, i) {
-          user = u;
-          info = i;
-          done();
-        })
-        .req(function(req) {
-          req.body = {};
-          req.body.uniqToken = 'sdvoihweui3498d9vhwoufhi8h';
-        })
-        .authenticate();
-    });
+      var info, status;
 
-    it('should supply user', function() {
-      expect(user).to.be.an.object;
-      expect(user.id).to.equal('1234');
-    });
+      before(function(done) {
+        chai.passport(strategy)
+          .fail(function(i, s) {
+            info = i;
+            status = s;
+            done();
+          })
+          .req(function(req) {
+            req.body = {};
+            req.body.uniqtoken = 'sdvoihweui3498d9vhwoufhi8h';
+          })
+          .authenticate();
+      });
 
-    it('should supply info', function() {
-      expect(info).to.be.an.object;
-      expect(info.scope).to.equal('read');
+      it('should fail with info and status', function() {
+        expect(info).to.be.an.object;
+        expect(info.message).to.equal('Missing credentials');
+        expect(status).to.equal(400);
+      });
     });
   });
 

--- a/tests/strategy.fields.test.js
+++ b/tests/strategy.fields.test.js
@@ -42,6 +42,42 @@ describe('Strategy', function() {
     });
   });
 
+  describe('handling a request with valid credentials in body using case sensitive custom field name', function() {
+    var strategy = new Strategy({tokenField: 'uniqToken', caseSensitive: true}, function(token, done) {
+      if (token === 'sdvoihweui3498d9vhwoufhi8h') {
+        return done(null, {id: '1234'}, {scope: 'read'});
+      }
+      return done(null, false);
+    });
+
+    var user,
+      info;
+
+    before(function(done) {
+      chai.passport(strategy)
+        .success(function(u, i) {
+          user = u;
+          info = i;
+          done();
+        })
+        .req(function(req) {
+          req.body = {};
+          req.body.uniqToken = 'sdvoihweui3498d9vhwoufhi8h';
+        })
+        .authenticate();
+    });
+
+    it('should supply user', function() {
+      expect(user).to.be.an.object;
+      expect(user.id).to.equal('1234');
+    });
+
+    it('should supply info', function() {
+      expect(info).to.be.an.object;
+      expect(info.scope).to.equal('read');
+    });
+  });
+
   describe('handling a request with valid credentials in body using custom field names with object notation', function() {
     var strategy = new Strategy({tokenField: 'token[unique]'}, function(token, done) {
       if (token === 'sdvoihweui3498d9vhwoufhi8h') {


### PR DESCRIPTION
With this PR we support case sensitive tokens, allowing to use the token like this:

```javascript
function get(req, res, next) {
   // Before: const { pagetoken: pageToken } = req.params;
   const { pageToken } = req.params;

   // Implement additional logic with the token
   const information = getImportantInformationWithToken(pageToken);
   ...
}

router.get('/clients/:pageToken', passport.authenticate('token', { session: false }), get);
```