### PR TITLE
Avoid OS specific commands for the development process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-test:
-	@NODE_ENV="test" \
-	./node_modules/.bin/mocha --reporter spec -u tdd --require "chai" --require ./tests/bootstrap/node tests/*.test.js
-
-lint:
-	./node_modules/gulp/bin/gulp.js lint
-
-.PHONY: test

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
         "chai-passport-strategy": "0.1.x",
         "gulp": "^3.6.2",
         "gulp-jshint": "^1.6.1",
-        "istanbul": "^0.2.9"
+        "istanbul": "^0.2.9",
+        "cross-env": "^5.0.1"
     },
     "engines": {
         "node": ">= 0.4.0"
     },
     "scripts": {
-        "test": "make test"
+        "test": "cross-env NODE_ENV=test mocha --reporter spec -u tdd --require \"chai\" --require ./tests/bootstrap/node tests/*.test.js",
+        "lint": "gulp lint"
     },
     "licenses" : [
         {


### PR DESCRIPTION
With this PR we can use any OS and execute the tests and linting scripts without Makefile and in all the OS (like Windows)

**To run the tests**

```shell
$ npm t
$ npm run test
```

**To run the linting tools**
```shell
$ npm run lint
````